### PR TITLE
fix: add dependency on small_gicp ROS package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>tf2_eigen</depend>
   <depend>ndt_omp</depend>
   <depend>fast_gicp</depend>
+  <depend>small_gicp</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>geodesy</depend>


### PR DESCRIPTION
A few months ago the package.xml was added to small_gicp repository, which makes it a ROS2 package. Unfortunately, it still lacks proper ament exports in CMakeLists.txt file, however it should be enough to properly handle build order.

Adding dependency on small_gicp to package.xml should remove the need to perform two step build process as it is described now in https://github.com/aserbremen/Multi-Robot-Graph-SLAM/tree/main?tab=readme-ov-file#installation.
