### PR TITLE
feat: add ENU frame for GPS processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ find_package(rclpy REQUIRED)
 # small_gicp
 find_package(small_gicp REQUIRED)
 
+# Geographiclib installs FindGeographicLib.cmake to this non-standard location
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
+find_package(GeographicLib REQUIRED)
+
 if (ament_cmake_FOUND)
   add_definitions(-DROS_AVAILABLE=2)
 endif ()
@@ -259,6 +263,7 @@ ament_target_dependencies(mrg_slam_component
   tf2_geometry_msgs
   tf2_eigen
   geodesy
+  GeographicLib
   message_filters
   builtin_interfaces
   std_msgs

--- a/config/mrg_slam.yaml
+++ b/config/mrg_slam.yaml
@@ -218,6 +218,9 @@ mrg_slam_component:
     gps_edge_robust_kernel_size: 1.0
     gps_edge_stddev_xy: 20.0
     gps_edge_stddev_z: 5.0
+    gps_use_enu: false # whether to treat local Cartesian coordinates as ENU or UTM coordinate system for GPS calculations
+    gps_enu_origin_from_msg: true # whether to calculate ENU frame origin from the first matched GPS message
+    gps_enu_origin: [0.0, 0.0, 0.0] # latitude, longitude, ellipsoidal height. Origin of the local ENU frame in WGS 84 (EPSG:4979) coordinates
     # IMU orientation
     imu_orientation_edge_robust_kernel: "NONE"
     imu_orientation_edge_stddev: 1.0

--- a/include/mrg_slam/gps_processor.hpp
+++ b/include/mrg_slam/gps_processor.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/optional.hpp>
 #include <deque>
+#include <geographic_msgs/msg/geo_point.hpp>
 #include <geographic_msgs/msg/geo_point_stamped.hpp>
 #include <mrg_slam/graph_slam.hpp>
 #include <mrg_slam/keyframe.hpp>
@@ -13,6 +14,7 @@
 #include <nmea_msgs/msg/sentence.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <GeographicLib/LocalCartesian.hpp>
 
 
 namespace mrg_slam {
@@ -30,6 +32,8 @@ public:
     bool flush( std::shared_ptr<GraphSLAM> &graph_slam, const std::vector<KeyFrame::Ptr> &keyframes );
 
     const boost::optional<Eigen::Vector3d> &zero_utm() const { return zero_utm_vec; }
+    const boost::optional<Eigen::Vector3d> &zero_enu() const { return zero_enu_vec; }
+    const boost::optional<geographic_msgs::msg::GeoPoint> &enu_origin() const { return gps_enu_origin; }
 
 private:
     rclcpp::Subscription<nmea_msgs::msg::Sentence>::SharedPtr              nmea_sub;
@@ -44,9 +48,14 @@ private:
     double                                                       gps_edge_stddev_z;
     std::string                                                  gps_edge_robust_kernel;
     double                                                       gps_edge_robust_kernel_size;
+    bool                                                         gps_use_enu;
+    bool                                                         gps_enu_origin_from_msg;
     boost::optional<Eigen::Vector3d>                             zero_utm_vec;
+    boost::optional<Eigen::Vector3d>                             zero_enu_vec;
+    boost::optional<geographic_msgs::msg::GeoPoint>              gps_enu_origin;
     std::mutex                                                   gps_queue_mutex;
     std::deque<geographic_msgs::msg::GeoPointStamped::SharedPtr> gps_queue;
+    GeographicLib::LocalCartesian                                local_cartesian;
 };
 
 }  // namespace mrg_slam

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <depend>geographic_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>mrg_slam_msgs</depend>
+  <depend>geographiclib</depend>
   <!-- ROS2 python dependencies -->
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <depend>rclpy</depend>


### PR DESCRIPTION
Using UTM for converting GPS position to local frame has a major issue - UTM space is not continuous and as the current code doesn't support changing UTM zones as a result  it doesn't work in infinite number of places on Earth ;)

On the other hand, using WGS84 based ENU local frame works for every place on Earth.
I prepared alternative implementation of GPS handling using ENU frame.
A few implementation details:
- ENU frame is chosen automatically based on the first point or its origin can be given as a parameter
- There is the zero_enu_vec vector used similar to the zero_utm_vec vector which is not necessary in theory as ENU frame origin should be enough, but it is necessary in practice to be compatible with the fix_first_node mode.
- GeographicLib is used for LLA->ENU conversion.
