### PR TITLE
fixed bug: gps initializes time offset from decimal seconds

### DIFF
--- a/src/mrg_slam/gps_processor.cpp
+++ b/src/mrg_slam/gps_processor.cpp
@@ -79,7 +79,7 @@ GpsProcessor::gps_callback( geographic_msgs::msg::GeoPointStamped::SharedPtr gps
     std::lock_guard<std::mutex> lock( gps_queue_mutex );
     // TODO check if this works
     gps_msg->header.stamp =
-        ( rclcpp::Time( gps_msg->header.stamp ) + rclcpp::Duration( gps_time_offset, 0 ) ).operator builtin_interfaces::msg::Time();
+        ( rclcpp::Time( gps_msg->header.stamp ) + rclcpp::Duration::from_seconds( gps_time_offset ) ).operator builtin_interfaces::msg::Time();
     gps_queue.push_back( gps_msg );
 }
 


### PR DESCRIPTION
The fix allows to define GPS time offset in decimal seconds. Without it the decimal part of the offset is implicitly discarded and the offset is effectively rounded down to the nearest integer.